### PR TITLE
Changed the way an integer type is chosen for unimodular matrix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LLLplus.jl
 
 [![Build Status](https://travis-ci.org/christianpeel/LLLplus.jl.svg?branch=master)](https://travis-ci.org/christianpeel/LLLplus.jl)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://pkg.julialang.org/docs/LLLplus/)
 
 LLLplus includes
 [Lenstra-Lenstra-Lovász](https://en.wikipedia.org/wiki/Lenstra%E2%80%93Lenstra%E2%80%93Lov%C3%A1sz_lattice_basis_reduction_algorithm)

--- a/benchmark/perftest.jl
+++ b/benchmark/perftest.jl
@@ -8,6 +8,14 @@ using Quadmath
 
 include("lrtest.jl")
 
+# getIntType is used to indicate what type we want the unimodular integer
+# matrix to have. We need to add methods of getIntType to handle the
+# DoubleFloats and Quadmath, since they are external packages that LLLplus
+# doesn't know about. So yes, we do a bit of type piracy.
+import LLLplus.getIntType
+getIntType(Td::Type{Tr}) where {Tr<:Float128} = Int128
+getIntType(Td::Type{Tr}) where {Tr<:Double64} = Int128
+
 lrtest(40,2 .^[7],[100],[Int32,Int64,Int128,Float32,Float64,Float128,Double64,BigInt,BigFloat],"rand")
 savefig("perfVsDataType.png")
 


### PR DESCRIPTION
When the input basis is float, an integer type to use for the unimodular matrix must be chosen.  This commit changes the way an integer type is chosen; multiple dispatch is now used.

Also adds a link to the docs at pkg.julialang.org