### PR TITLE
Make reduction procedures work for immutable input arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ julia = "1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [targets]
-test = ["Test", "Random", "Documenter"]
+test = ["Test", "Random", "Documenter", "StaticArrays"]

--- a/src/brun.jl
+++ b/src/brun.jl
@@ -37,16 +37,16 @@ function brun(H::AbstractArray{Td,2}) where Td
 
     grammian = H'*H
     metric_vec = sqrt.(abs.(diag(grammian')))
-    mu  = grammian[:,1] # initialize mu with an arbitrary column of the Grammian
+    mu = copy!(similar(grammian[:,1]), @view grammian[:,1]) # initialize mu with an arbitrary column of the Grammian
     T = Matrix{Ti}(I, K, K)   # unimodular transformation matrix 
-    B = copy(H) 
+    B = copy!(similar(H), H)
 
     doBrun = true
     while doBrun
 
         # Calculation of Brun's update value
         _,s = findmax(mu)
-        zw = copy(mu)
+        zw = copy!(similar(mu), mu)
         zw[s] = minimum(mu)[1]-one(Td) # previously zw[s] = -typemax(zw[1])
         _,t = findmax(zw)
         r = round(mu[s]/mu[t])

--- a/src/brun.jl
+++ b/src/brun.jl
@@ -37,7 +37,7 @@ function brun(H::AbstractArray{Td,2}) where Td
 
     grammian = H'*H
     metric_vec = sqrt.(abs.(diag(grammian')))
-    mu = copy!(similar(grammian[:,1]), @view grammian[:,1]) # initialize mu with an arbitrary column of the Grammian
+    mu = copy!(similar(grammian, size(grammian, 2)), @view grammian[:,1]) # initialize mu with an arbitrary column of the Grammian
     T = Matrix{Ti}(I, K, K)   # unimodular transformation matrix 
     B = copy!(similar(H), H)
 

--- a/src/l2.jl
+++ b/src/l2.jl
@@ -76,7 +76,7 @@ function l2(H::AbstractArray{Td,2},TG::Type{Tg}=Td,δ=.75,η=.51) where
 
     δ= Tfe(δ);
     η= Tfe(η)
-    B = copy(H)
+    B = copy!(similar(H), H)
     G = Tg.(B)'*B
     ηb= (η+.5)/2
     δb= (δ+1)/2
@@ -236,7 +236,7 @@ function l2turbo(H::AbstractArray{Td,2},TG::Type{Tg}=Td,δ=.75,η=.51) where
 
     δ= Tfe(δ);
     η= Tfe(η)
-    B = copy(H)
+    B = copy!(similar(H), H)
     G = Tg.(B)'*B
     ηb= (η+.5)/2
     δb= (δ+1)/2

--- a/src/lll.jl
+++ b/src/lll.jl
@@ -43,7 +43,7 @@ if Td<:Rational
     @warn "`lll` does not handle Rationals well; try `l2`."
 end
 
-B = copy(H);
+B = copy!(similar(H), H)
 N,L = size(B);
 Qt,R = qr(B);
 Q = Matrix(Qt); # A few cycles can be saved by removing Q and T
@@ -210,7 +210,7 @@ julia> N=100;H = randn(N,N); B,T = sizereduction(H);
 ```
 """
 function sizereduction(H::Array{Td,2}) where {Td}
-    B = copy(H);
+    B = copy!(similar(H), H)
     L = size(B,2);
     Q,R = qr(B);
 

--- a/src/seysen.jl
+++ b/src/seysen.jl
@@ -28,7 +28,7 @@ julia> H= BigFloat.([1.5 2; 3 4]) .+ 2im; B,_= seysen(H); B
 
 ```
 """
-function seysen(H::Array{Td,2}) where {Td}
+function seysen(H::AbstractMatrix{Td}) where {Td}
 
 if Td<:BigInt || Td<:BigFloat
     Ti= Td<:Complex ? Complex{BigInt} : BigInt
@@ -43,7 +43,7 @@ end
 n,m = size(H); # m-dimensional lattice in an n-dimensional space
 
 # initialization, outputs
-B      = copy(H);    # reduced lattice basis
+B      = copy!(similar(H), H) # reduced lattice basis
 num_it = 0;          # number of iterations
 T      = Matrix{Ti}(I, m, m)  # unimodular matrix
 A      = (H'*H)*1.0;          # Gram matrix of H

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -1,0 +1,12 @@
+using StaticArrays, Test
+
+@testset "Compatibility with StaticArrays/immutable arrays" begin
+    H = [0.9628813734720784 0.23481870903463398 0.09437229281315995; 
+         0.6398958697159318 0.19228011953230373 0.7960518809701681; 
+         0.9766849678971312 0.6302875815478448 0.4788314270985644]
+    sH = SMatrix{3, 3, Float64, 9}(H)
+    @test lll(H)[1] ≈ lll(sH)[1]
+    @test l2(H)[1] ≈ l2(sH)[1]
+    @test brun(H)[1] ≈ brun(sH)[1]
+    @test seysen(H)[1] ≈ seysen(sH)[1]
+end


### PR DESCRIPTION
The main motivation here is to make `lll` etc. work for input matrices that do not implement `setindex!` - e.g., an `SMatrix`.